### PR TITLE
Fix ripple effect and dividers

### DIFF
--- a/app/src/main/java/pl/kitek/rvwithcardview/ItemsAdapter.kt
+++ b/app/src/main/java/pl/kitek/rvwithcardview/ItemsAdapter.kt
@@ -72,7 +72,7 @@ class ItemsAdapter(private val items: List<Item>) : RecyclerView.Adapter<ItemsAd
 
         private fun bindOutlineProvider(itemView: View, position: Int, size: Int) {
             if (!isLollipop()) return
-            itemView.outlineProvider = if (size == 1 || position == 0) defaultOutline else fixedOutline
+            itemView.outlineProvider = if (size == 1 || position == 0 || position == size - 1) defaultOutline else fixedOutline
         }
     }
 }

--- a/app/src/main/java/pl/kitek/rvwithcardview/MainActivity.kt
+++ b/app/src/main/java/pl/kitek/rvwithcardview/MainActivity.kt
@@ -1,9 +1,18 @@
 package pl.kitek.rvwithcardview
 
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
 import android.os.Bundle
+import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.RecyclerView.ItemDecoration
+import android.view.View
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlin.math.roundToInt
+
 
 class MainActivity : AppCompatActivity() {
 
@@ -13,6 +22,11 @@ class MainActivity : AppCompatActivity() {
 
         itemsRv.layoutManager = LinearLayoutManager(this)
         itemsRv.adapter = ItemsAdapter((1..10).map { createItem(it) })
+
+        //https://stackoverflow.com/questions/31242812/how-can-a-divider-line-be-added-in-an-android-recyclerview
+        //https://stackoverflow.com/questions/31242812/how-can-a-divider-line-be-added-in-an-android-recyclerview
+        val dividerItemDecoration = DividerItemDecorator(ContextCompat.getDrawable(this, R.drawable.divider))
+        itemsRv.addItemDecoration(dividerItemDecoration)
     }
 
     private fun createItem(position: Int): Item {
@@ -21,5 +35,47 @@ class MainActivity : AppCompatActivity() {
                 "Item $position",
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
         )
+    }
+
+
+    // Source: https://stackoverflow.com/a/49722959/2848021
+    class DividerItemDecorator(private val mDivider: Drawable) : ItemDecoration() {
+        private val bounds: Rect = Rect()
+
+        override fun onDraw(canvas: Canvas?, parent: RecyclerView?, state: RecyclerView.State?) {
+            if (canvas == null || parent == null) return
+            canvas.save()
+            val left: Int
+            val right: Int
+            if (parent.clipToPadding) {
+                left = parent.paddingLeft
+                right = parent.width - parent.paddingRight
+                canvas.clipRect(left, parent.paddingTop, right,
+                        parent.height - parent.paddingBottom)
+            } else {
+                left = 0
+                right = parent.width
+            }
+
+            val childCount = parent.childCount
+            for (i in 0 until childCount - 1) {
+                val child: View = parent.getChildAt(i)
+                parent.getDecoratedBoundsWithMargins(child, bounds)
+                val bottom = (bounds.bottom + child.translationY.roundToInt())
+                val top = bottom - mDivider.intrinsicHeight
+                mDivider.setBounds(left, top, right, bottom)
+                mDivider.draw(canvas)
+            }
+            canvas.restore()
+        }
+
+        override fun getItemOffsets(outRect: Rect?, view: View?, parent: RecyclerView?, state: RecyclerView.State?) {
+            if (parent == null || outRect == null || state == null) return
+            if (parent.getChildAdapterPosition(view) == state.itemCount - 1) {
+                outRect.setEmpty();
+            } else {
+                outRect.set(0, 0, 0, mDivider.intrinsicHeight)
+            }
+        }
     }
 }

--- a/app/src/main/res/drawable-v21/item_bottom.xml
+++ b/app/src/main/res/drawable-v21/item_bottom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="?android:colorAccent" />
+            <corners
+                android:bottomLeftRadius="@dimen/cardRadius"
+                android:bottomRightRadius="@dimen/cardRadius" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/white" />
+            <corners
+                android:bottomLeftRadius="@dimen/cardRadius"
+                android:bottomRightRadius="@dimen/cardRadius" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable-v21/item_middle.xml
+++ b/app/src/main/res/drawable-v21/item_middle.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/white" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable-v21/item_top.xml
+++ b/app/src/main/res/drawable-v21/item_top.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="?android:colorAccent" />
+            <corners
+                android:topLeftRadius="@dimen/cardRadius"
+                android:topRightRadius="@dimen/cardRadius" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/white" />
+            <corners
+                android:topLeftRadius="@dimen/cardRadius"
+                android:topRightRadius="@dimen/cardRadius" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable-v21/item_top_bottom.xml
+++ b/app/src/main/res/drawable-v21/item_top_bottom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="?android:colorAccent" />
+            <corners android:radius="@dimen/cardRadius" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/white" />
+            <corners android:radius="@dimen/cardRadius" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/divider.xml
+++ b/app/src/main/res/drawable/divider.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <size android:height="1dp" />
+    <solid android:color="@color/colorPrimaryBorder" />
+</shape>

--- a/app/src/main/res/layout/item.xml
+++ b/app/src/main/res/layout/item.xml
@@ -6,7 +6,6 @@
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
-    android:foreground="?android:attr/selectableItemBackground"
     android:padding="16dp"
     tools:ignore="RtlHardcoded">
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="cardElevation">2dp</dimen>
-    <dimen name="cardRadius">2dp</dimen>
+    <dimen name="cardRadius">8dp</dimen>
 </resources>


### PR DESCRIPTION
Using foreground would cause the ripple effect to be shown in the entire view (it does not clip to the outline/background).

Instead, I've created new resources using ripple. Either foreground and ripple only works for API >= 21, so we are not losing anything here.

Also, instead of borders, I've added a divider 👍 

I've kept the borders for the drawables < 21, as there is no elevation in this versions.